### PR TITLE
IA: TimedCrowdsale

### DIFF
--- a/contracts/protocol/note-sale/crowdsale/TimedCrowdsale.sol
+++ b/contracts/protocol/note-sale/crowdsale/TimedCrowdsale.sol
@@ -17,17 +17,6 @@ abstract contract TimedCrowdsale is Crowdsale {
     event UpdateUsingTimeLimit(bool isEnableTimeLimit);
     event UpdateSaleRoundTime(uint256 newOpeningTime, uint256 newClosingTime);
 
-    function __TimedCrowdsale__init(
-        Registry _registry,
-        address _pool,
-        address _token,
-        address _currency
-    ) internal onlyInitializing {
-        __Crowdsale__init(_registry, _pool, _token, _currency);
-
-        isEnableTimeLimit = true;
-    }
-
     modifier onlyWhileOpen() {
         require(isOpen() || isLongSale(), 'TimedCrowdsale: not open');
         _;


### PR DESCRIPTION
 - remove unused __TimedCrowdsale__init ---  TimedCrowdsale.__TimedCrowdsale__init(Registry,address,address,address) (contracts/protocol/note-sale/crowdsale/TimedCrowdsale.sol#15-24) is never used and should be removed